### PR TITLE
Add standalone web viewer for browsing and searching downloaded receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,38 @@ The extension adds a small card interface to your Costco Order Status page:
 5. Click "Download Receipts"
 6. Your receipts will be downloaded as `costco-[timestamp].json`
 
+## Receipt Viewer
+
+The repository includes a standalone web viewer ([`viewer/`](viewer/)) for browsing and searching the JSON file you download. It runs entirely in your browser — no build step, no server, and no data ever leaves your machine.
+
+### Running it
+
+**Option 1 — Open the file directly (simplest):**
+
+```bash
+open viewer/index.html
+```
+
+This opens the viewer in your default browser via the `file://` protocol. All parsing and searching happen client-side, so this is all you need.
+
+**Option 2 — Serve it locally (if you prefer `http://`):**
+
+From the repository root:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit [http://localhost:8000/viewer/](http://localhost:8000/viewer/) and stop the server with `Ctrl+C` when done. (`npx serve` works too.)
+
+### Using the viewer
+
+1. Click the dropzone (or drag and drop) and select your downloaded `costco-[timestamp].json` file.
+2. The viewer parses the file and shows summary stats (receipt count, net total, instant savings, warehouses visited) plus a list of receipts.
+3. Type in the **search box** to filter receipts in real time — it matches product descriptions, item numbers, warehouse name/city/state/zip, transaction type, dates, totals, and payment methods (e.g. `modelo`, `redwood city`, `refund`). Matches are highlighted.
+4. Click any receipt to expand its line items, taxes, payment tender, and savings.
+5. Click **"Load different file"** to start over with another JSON export.
+
 ## File Structure
 
 ```
@@ -61,6 +93,10 @@ costco-receipt-downloader/
 ├── manifest-chrome.json        # Chrome manifest (Manifest V3)
 ├── content.js                  # Main extension script
 ├── styles.css                  # CSS for script
+├── viewer/                     # Standalone web viewer for the downloaded JSON
+│   ├── index.html              # Viewer page (upload + search UI)
+│   ├── viewer.css              # Viewer styles
+│   └── viewer.js               # Parsing, rendering, and search logic
 ├── package.json                # npm build scripts (optional)
 ├── README.md                   # This file
 ├── CONTRIBUTING.md             # Contribution guidelines
@@ -193,7 +229,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 - [ ] Add support for online order receipts
 - [ ] Export to CSV format
-- [ ] Receipt search and filter functionality
+- [x] Receipt search and filter functionality
 - [ ] Spending analytics dashboard
 - [ ] Multi-language support
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Costco Receipt Viewer</title>
+  <link rel="stylesheet" href="viewer.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1 class="app-title">Costco Receipt Viewer</h1>
+    <p class="app-subtitle">Upload your downloaded receipts JSON to browse and search your purchases.</p>
+  </header>
+
+  <!-- Upload state -->
+  <section id="upload-view" class="upload-view">
+    <div id="dropzone" class="dropzone" tabindex="0" role="button" aria-label="Upload receipts JSON file">
+      <div class="dropzone-icon">📄</div>
+      <div class="dropzone-text">
+        <strong>Click to choose a file</strong> or drag &amp; drop it here
+      </div>
+      <div class="dropzone-hint">Expects the receipts <code>.json</code> exported by the Costco Receipt Downloader.</div>
+      <input id="file-input" type="file" accept="application/json,.json" hidden />
+    </div>
+    <p id="upload-error" class="upload-error" hidden></p>
+  </section>
+
+  <!-- Data state -->
+  <section id="data-view" class="data-view" hidden>
+    <div class="toolbar">
+      <div class="search-wrap">
+        <input
+          id="search-box"
+          class="search-box"
+          type="search"
+          placeholder="Search products, warehouses, dates, totals…"
+          autocomplete="off"
+          aria-label="Search receipts"
+        />
+      </div>
+      <div class="toolbar-actions">
+        <span id="result-summary" class="result-summary"></span>
+        <button id="reset-btn" class="ghost-btn" type="button">Load different file</button>
+      </div>
+    </div>
+
+    <div id="summary-bar" class="summary-bar"></div>
+
+    <div id="receipts" class="receipts"></div>
+    <p id="empty-state" class="empty-state" hidden>No receipts match your search.</p>
+  </section>
+
+  <script src="viewer.js"></script>
+</body>
+</html>

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -1,0 +1,368 @@
+:root {
+  --costco-blue: #0067b8;
+  --costco-blue-dark: #005a9e;
+  --costco-red: #e31837;
+  --text: #1a1a1a;
+  --text-muted: #555;
+  --border: #e0e0e0;
+  --bg: #f4f5f7;
+  --card-bg: #ffffff;
+  --green: #28a745;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.app-header {
+  background: var(--costco-blue);
+  color: #fff;
+  padding: 24px 24px 20px;
+}
+
+.app-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.app-subtitle {
+  margin: 6px 0 0;
+  font-size: 14px;
+  opacity: 0.9;
+}
+
+/* ---------- Upload view ---------- */
+.upload-view {
+  max-width: 640px;
+  margin: 48px auto;
+  padding: 0 16px;
+}
+
+.dropzone {
+  border: 2px dashed var(--costco-blue);
+  border-radius: 12px;
+  background: var(--card-bg);
+  padding: 48px 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.dropzone:hover,
+.dropzone:focus-visible {
+  background: #eef5fb;
+  outline: none;
+}
+
+.dropzone.dragover {
+  background: #e3f0fa;
+  border-color: var(--costco-blue-dark);
+}
+
+.dropzone-icon {
+  font-size: 40px;
+  margin-bottom: 12px;
+}
+
+.dropzone-text {
+  font-size: 16px;
+  color: var(--text);
+}
+
+.dropzone-hint {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.dropzone-hint code {
+  background: #f0f0f0;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.upload-error {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border-radius: 6px;
+  background: #fdecee;
+  color: var(--costco-red);
+  font-size: 14px;
+  text-align: center;
+}
+
+/* ---------- Data view ---------- */
+.data-view {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 16px 64px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  padding: 12px 0;
+  z-index: 5;
+}
+
+.search-wrap {
+  flex: 1 1 320px;
+}
+
+.search-box {
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 15px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: var(--card-bg);
+}
+
+.search-box:focus {
+  outline: none;
+  border-color: var(--costco-blue);
+  box-shadow: 0 0 0 3px rgba(0, 103, 184, 0.15);
+}
+
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.result-summary {
+  font-size: 13px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.ghost-btn {
+  background: transparent;
+  border: 1px solid var(--costco-blue);
+  color: var(--costco-blue);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ghost-btn:hover {
+  background: var(--costco-blue);
+  color: #fff;
+}
+
+.summary-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 4px 0 20px;
+}
+
+.stat-card {
+  flex: 1 1 140px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.stat-value {
+  font-size: 20px;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+/* ---------- Receipt cards ---------- */
+.receipts {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.receipt-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.receipt-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.receipt-head:hover {
+  background: #f7fafd;
+}
+
+.receipt-head-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.receipt-warehouse {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.receipt-meta {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.receipt-head-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  white-space: nowrap;
+}
+
+.receipt-total {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.receipt-total.refund {
+  color: var(--costco-red);
+}
+
+.type-badge {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: #e8f0fb;
+  color: var(--costco-blue);
+}
+
+.type-badge.refund {
+  background: #fdecee;
+  color: var(--costco-red);
+}
+
+.chevron {
+  transition: transform 0.15s;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.receipt-card.open .chevron {
+  transform: rotate(90deg);
+}
+
+.receipt-body {
+  border-top: 1px solid var(--border);
+  padding: 8px 16px 16px;
+}
+
+.receipt-card:not(.open) .receipt-body {
+  display: none;
+}
+
+.address {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 8px 0 12px;
+}
+
+table.items {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+table.items th {
+  text-align: left;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  padding: 6px 8px;
+}
+
+table.items td {
+  padding: 6px 8px;
+  border-bottom: 1px solid #f0f0f0;
+  vertical-align: top;
+}
+
+table.items td.num,
+table.items th.num {
+  text-align: right;
+  white-space: nowrap;
+}
+
+tr.item-discount td {
+  color: var(--green);
+}
+
+.item-desc-2 {
+  display: block;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.item-number {
+  font-size: 11px;
+  color: #999;
+}
+
+.receipt-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.receipt-footer .savings {
+  color: var(--green);
+  font-weight: 600;
+}
+
+mark {
+  background: #fff3b0;
+  padding: 0 1px;
+  border-radius: 2px;
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--text-muted);
+  margin-top: 40px;
+  font-size: 15px;
+}

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1,0 +1,423 @@
+/* Costco Receipt Viewer
+ * Standalone client-side viewer for the receipts JSON exported by the
+ * Costco Receipt Downloader. No build step or server required — open
+ * index.html in a browser, upload the .json, browse and search.
+ */
+(function () {
+  "use strict";
+
+  /** @type {Array<Object>} The parsed receipt records. */
+  let receipts = [];
+
+  // --- Element references -------------------------------------------------
+  const uploadView = document.getElementById("upload-view");
+  const dataView = document.getElementById("data-view");
+  const dropzone = document.getElementById("dropzone");
+  const fileInput = document.getElementById("file-input");
+  const uploadError = document.getElementById("upload-error");
+
+  const searchBox = document.getElementById("search-box");
+  const resetBtn = document.getElementById("reset-btn");
+  const resultSummary = document.getElementById("result-summary");
+  const summaryBar = document.getElementById("summary-bar");
+  const receiptsEl = document.getElementById("receipts");
+  const emptyState = document.getElementById("empty-state");
+
+  // --- Formatting helpers -------------------------------------------------
+  const currency = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  });
+
+  function formatMoney(value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? currency.format(n) : "—";
+  }
+
+  function formatDate(receipt) {
+    const raw = receipt.transactionDateTime || receipt.transactionDate;
+    if (!raw) return "Unknown date";
+    const d = new Date(raw);
+    if (isNaN(d.getTime())) return String(raw);
+    return d.toLocaleString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+
+  function escapeHtml(str) {
+    return String(str == null ? "" : str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function escapeRegExp(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  // --- File handling ------------------------------------------------------
+  function showError(message) {
+    uploadError.textContent = message;
+    uploadError.hidden = false;
+  }
+
+  function clearError() {
+    uploadError.hidden = true;
+    uploadError.textContent = "";
+  }
+
+  function handleFile(file) {
+    clearError();
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = function () {
+      let data;
+      try {
+        data = JSON.parse(reader.result);
+      } catch (err) {
+        showError("Could not parse the file as JSON: " + err.message);
+        return;
+      }
+
+      // The export is an array of receipts. Be lenient about a wrapper object.
+      if (!Array.isArray(data)) {
+        if (data && Array.isArray(data.receipts)) {
+          data = data.receipts;
+        } else {
+          showError(
+            "Unexpected JSON shape — expected an array of receipt objects."
+          );
+          return;
+        }
+      }
+
+      if (data.length === 0) {
+        showError("The file parsed correctly but contains no receipts.");
+        return;
+      }
+
+      receipts = data;
+      enterDataView();
+    };
+    reader.onerror = function () {
+      showError("Failed to read the file.");
+    };
+    reader.readAsText(file);
+  }
+
+  // --- View transitions ---------------------------------------------------
+  function enterDataView() {
+    uploadView.hidden = true;
+    dataView.hidden = false;
+    searchBox.value = "";
+    renderSummary();
+    render("");
+    searchBox.focus();
+  }
+
+  function resetToUpload() {
+    receipts = [];
+    dataView.hidden = true;
+    uploadView.hidden = false;
+    fileInput.value = "";
+    clearError();
+  }
+
+  // --- Search -------------------------------------------------------------
+  // Build a lowercase searchable blob per receipt once, lazily cached on the
+  // record itself so repeated keystrokes stay cheap.
+  function searchableText(receipt) {
+    if (receipt.__search) return receipt.__search;
+    const parts = [
+      receipt.warehouseName,
+      receipt.warehouseShortName,
+      receipt.warehouseCity,
+      receipt.warehouseState,
+      receipt.warehousePostalCode,
+      receipt.warehouseAddress1,
+      receipt.transactionType,
+      receipt.transactionDate,
+      receipt.transactionDateTime,
+      receipt.transactionBarcode,
+      receipt.total,
+    ];
+    (receipt.itemArray || []).forEach(function (item) {
+      parts.push(
+        item.itemDescription01,
+        item.itemDescription02,
+        item.itemNumber,
+        item.amount
+      );
+    });
+    (receipt.tenderArray || []).forEach(function (t) {
+      parts.push(t.tenderDescription, t.displayAccountNumber);
+    });
+    const blob = parts
+      .filter(function (p) {
+        return p != null && p !== "";
+      })
+      .join("  ")
+      .toLowerCase();
+    Object.defineProperty(receipt, "__search", {
+      value: blob,
+      enumerable: false,
+    });
+    return blob;
+  }
+
+  function matches(receipt, query) {
+    if (!query) return true;
+    return searchableText(receipt).includes(query);
+  }
+
+  // --- Rendering ----------------------------------------------------------
+  function renderSummary() {
+    const count = receipts.length;
+    const totalSpent = receipts.reduce(function (sum, r) {
+      const n = Number(r.total);
+      return sum + (Number.isFinite(n) ? n : 0);
+    }, 0);
+    const totalSavings = receipts.reduce(function (sum, r) {
+      const n = Number(r.instantSavings);
+      return sum + (Number.isFinite(n) ? n : 0);
+    }, 0);
+    const warehouses = new Set(
+      receipts.map(function (r) {
+        return r.warehouseName;
+      })
+    );
+
+    const cards = [
+      ["Receipts", String(count)],
+      ["Net total", formatMoney(totalSpent)],
+      ["Instant savings", formatMoney(totalSavings)],
+      ["Warehouses visited", String(warehouses.size)],
+    ];
+
+    summaryBar.innerHTML = cards
+      .map(function (c) {
+        return (
+          '<div class="stat-card"><div class="stat-label">' +
+          escapeHtml(c[0]) +
+          '</div><div class="stat-value">' +
+          escapeHtml(c[1]) +
+          "</div></div>"
+        );
+      })
+      .join("");
+  }
+
+  function highlight(text, query) {
+    const safe = escapeHtml(text);
+    if (!query) return safe;
+    const re = new RegExp("(" + escapeRegExp(escapeHtml(query)) + ")", "ig");
+    return safe.replace(re, "<mark>$1</mark>");
+  }
+
+  function renderItemsTable(receipt, query) {
+    const items = receipt.itemArray || [];
+    if (items.length === 0) return "<p class='address'>No line items.</p>";
+
+    const rows = items
+      .map(function (item) {
+        const isDiscount = Number(item.amount) < 0;
+        const desc2 = item.itemDescription02
+          ? '<span class="item-desc-2">' +
+            highlight(item.itemDescription02, query) +
+            "</span>"
+          : "";
+        return (
+          '<tr class="' +
+          (isDiscount ? "item-discount" : "") +
+          '">' +
+          "<td>" +
+          highlight(item.itemDescription01 || "(no description)", query) +
+          desc2 +
+          '<span class="item-number">#' +
+          highlight(item.itemNumber || "", query) +
+          "</span></td>" +
+          '<td class="num">' +
+          escapeHtml(item.unit) +
+          "</td>" +
+          '<td class="num">' +
+          formatMoney(item.amount) +
+          "</td>" +
+          "</tr>"
+        );
+      })
+      .join("");
+
+    return (
+      '<table class="items"><thead><tr>' +
+      "<th>Item</th><th class='num'>Qty</th><th class='num'>Amount</th>" +
+      "</tr></thead><tbody>" +
+      rows +
+      "</tbody></table>"
+    );
+  }
+
+  function renderReceiptCard(receipt, index, query) {
+    const isRefund = String(receipt.transactionType).toLowerCase() === "refund";
+    const itemCount = (receipt.itemArray || []).length;
+
+    const tenders = (receipt.tenderArray || [])
+      .map(function (t) {
+        const acct = t.displayAccountNumber ? " ••" + t.displayAccountNumber : "";
+        return escapeHtml(t.tenderDescription || "Payment") + escapeHtml(acct);
+      })
+      .join(", ");
+
+    const savings = Number(receipt.instantSavings) > 0
+      ? '<span class="savings">Saved ' +
+        formatMoney(receipt.instantSavings) +
+        "</span>"
+      : "";
+
+    const addressParts = [
+      receipt.warehouseAddress1,
+      receipt.warehouseCity,
+      receipt.warehouseState,
+      receipt.warehousePostalCode,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    return (
+      '<article class="receipt-card" data-index="' +
+      index +
+      '">' +
+      '<div class="receipt-head">' +
+      '<div class="receipt-head-main">' +
+      '<span class="receipt-warehouse">' +
+      highlight(receipt.warehouseName || "Costco", query) +
+      "</span>" +
+      '<span class="receipt-meta">' +
+      escapeHtml(formatDate(receipt)) +
+      " · " +
+      itemCount +
+      (itemCount === 1 ? " item" : " items") +
+      "</span>" +
+      "</div>" +
+      '<div class="receipt-head-right">' +
+      '<span class="type-badge ' +
+      (isRefund ? "refund" : "") +
+      '">' +
+      escapeHtml(receipt.transactionType || "Sales") +
+      "</span>" +
+      '<span class="receipt-total ' +
+      (isRefund ? "refund" : "") +
+      '">' +
+      formatMoney(receipt.total) +
+      "</span>" +
+      '<span class="chevron">▶</span>' +
+      "</div>" +
+      "</div>" +
+      '<div class="receipt-body">' +
+      '<div class="address">' +
+      highlight(addressParts, query) +
+      "</div>" +
+      renderItemsTable(receipt, query) +
+      '<div class="receipt-footer">' +
+      "<span>Subtotal: " +
+      formatMoney(receipt.subTotal) +
+      "</span>" +
+      "<span>Tax: " +
+      formatMoney(receipt.taxes) +
+      "</span>" +
+      (tenders ? "<span>Paid via: " + tenders + "</span>" : "") +
+      savings +
+      "</div>" +
+      "</div>" +
+      "</article>"
+    );
+  }
+
+  function render(query) {
+    const q = (query || "").trim().toLowerCase();
+
+    const filtered = [];
+    receipts.forEach(function (r, i) {
+      if (matches(r, q)) filtered.push({ receipt: r, index: i });
+    });
+
+    resultSummary.textContent =
+      q === ""
+        ? receipts.length + " receipts"
+        : filtered.length + " of " + receipts.length + " receipts";
+
+    if (filtered.length === 0) {
+      receiptsEl.innerHTML = "";
+      emptyState.hidden = false;
+      return;
+    }
+    emptyState.hidden = true;
+
+    // Highlighting needs the original-case query token.
+    const rawQuery = (query || "").trim();
+    receiptsEl.innerHTML = filtered
+      .map(function (f) {
+        return renderReceiptCard(f.receipt, f.index, rawQuery);
+      })
+      .join("");
+  }
+
+  // --- Events -------------------------------------------------------------
+  dropzone.addEventListener("click", function () {
+    fileInput.click();
+  });
+
+  dropzone.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      fileInput.click();
+    }
+  });
+
+  fileInput.addEventListener("change", function () {
+    handleFile(fileInput.files[0]);
+  });
+
+  ["dragenter", "dragover"].forEach(function (evt) {
+    dropzone.addEventListener(evt, function (e) {
+      e.preventDefault();
+      dropzone.classList.add("dragover");
+    });
+  });
+
+  ["dragleave", "drop"].forEach(function (evt) {
+    dropzone.addEventListener(evt, function (e) {
+      e.preventDefault();
+      dropzone.classList.remove("dragover");
+    });
+  });
+
+  dropzone.addEventListener("drop", function (e) {
+    const file = e.dataTransfer && e.dataTransfer.files[0];
+    handleFile(file);
+  });
+
+  // Debounce keystrokes so large files don't re-render on every character.
+  let searchTimer = null;
+  searchBox.addEventListener("input", function () {
+    clearTimeout(searchTimer);
+    const value = searchBox.value;
+    searchTimer = setTimeout(function () {
+      render(value);
+    }, 120);
+  });
+
+  resetBtn.addEventListener("click", resetToUpload);
+
+  // Expand / collapse cards via event delegation.
+  receiptsEl.addEventListener("click", function (e) {
+    const head = e.target.closest(".receipt-head");
+    if (!head) return;
+    head.parentElement.classList.toggle("open");
+  });
+})();


### PR DESCRIPTION
## Summary

Adds a standalone, client-side web viewer (`viewer/`) for browsing and searching the receipts JSON exported by the extension. It runs entirely in the browser — no build step, no server, and no data leaves the user's machine.

This addresses the "Receipt search and filter functionality" item on the roadmap.

## What's included

- **`viewer/index.html`** — Two-state UI: an upload dropzone, then the data view once a file is loaded.
- **`viewer/viewer.js`** — File parsing (with validation + friendly error messages), summary stats, receipt rendering, and real-time search.
- **`viewer/viewer.css`** — Styling consistent with the extension's Costco-blue theme (`#0067b8`).
- **`README.md`** — New "Receipt Viewer" section (how to run + how to use), updated File Structure, and checked off the roadmap item.

## Features

- **Upload** a `costco-[timestamp].json` file via click or drag-and-drop; tolerates both a bare array and a `{ receipts: [...] }` wrapper, with clear errors for invalid/empty/non-JSON input.
- **Summary stats**: receipt count, net total, total instant savings, and distinct warehouses visited.
- **Live search** (debounced) across product descriptions, item numbers, warehouse name/city/state/zip, transaction type, dates, totals, and payment methods — with match highlighting.
- **Collapsible receipt cards** showing line items, qty/amount (discounts in green), taxes, payment tender, and savings; refunds are visually distinguished.

## How to run

```bash
open viewer/index.html
```

Or serve over HTTP from the repo root:
```
python3 -m http.server 8000
# then visit http://localhost:8000/viewer/
```